### PR TITLE
add old analytics tag to pages

### DIFF
--- a/coming-soon.html
+++ b/coming-soon.html
@@ -6,14 +6,14 @@
 -->
 <html>
 	<head>
-				<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-GLYBWK8KS3"></script>
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-HCF3TFHZTR"></script>
 		<script>
-			window.dataLayer = window.dataLayer || [];
-			function gtag(){dataLayer.push(arguments);}
-			gtag('js', new Date());
+		  window.dataLayer = window.dataLayer || [];
+		  function gtag(){dataLayer.push(arguments);}
+		  gtag('js', new Date());
 
-			gtag('config', 'G-GLYBWK8KS3');
+		  gtag('config', 'G-HCF3TFHZTR');
 		</script>
 		<title>Coming soon</title>
 		<meta charset="utf-8" />

--- a/index.html
+++ b/index.html
@@ -6,14 +6,14 @@
 -->
 <html>
 	<head>
-				<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-GLYBWK8KS3"></script>
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-HCF3TFHZTR"></script>
 		<script>
 		  window.dataLayer = window.dataLayer || [];
 		  function gtag(){dataLayer.push(arguments);}
 		  gtag('js', new Date());
 
-		  gtag('config', 'G-GLYBWK8KS3');
+		  gtag('config', 'G-HCF3TFHZTR');
 		</script>
 		<title>Stefano Romanelli</title>
 		<meta charset="utf-8" />

--- a/onboarding.html
+++ b/onboarding.html
@@ -6,14 +6,14 @@
 -->
 <html>
 	<head>
-				<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-GLYBWK8KS3"></script>
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-HCF3TFHZTR"></script>
 		<script>
-			window.dataLayer = window.dataLayer || [];
-			function gtag(){dataLayer.push(arguments);}
-			gtag('js', new Date());
+		  window.dataLayer = window.dataLayer || [];
+		  function gtag(){dataLayer.push(arguments);}
+		  gtag('js', new Date());
 
-			gtag('config', 'G-GLYBWK8KS3');
+		  gtag('config', 'G-HCF3TFHZTR');
 		</script>
 		<title>Case study - AEAT app onboarding</title>
 		<meta charset="utf-8" />

--- a/resume.html
+++ b/resume.html
@@ -6,14 +6,14 @@
 -->
 <html>
 <head>
-		<!-- Global site tag (gtag.js) - Google Analytics -->
-	<script async src="https://www.googletagmanager.com/gtag/js?id=G-GLYBWK8KS3"></script>
+	<!-- Global site tag (gtag.js) - Google Analytics -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-HCF3TFHZTR"></script>
 	<script>
-	window.dataLayer = window.dataLayer || [];
-	function gtag(){dataLayer.push(arguments);}
-	gtag('js', new Date());
+	  window.dataLayer = window.dataLayer || [];
+	  function gtag(){dataLayer.push(arguments);}
+	  gtag('js', new Date());
 
-	gtag('config', 'G-GLYBWK8KS3');
+	  gtag('config', 'G-HCF3TFHZTR');
 	</script>
 	<title>Stefano Romanelli's resume</title>
 	<meta charset="utf-8" />


### PR DESCRIPTION
This PR switches to the old version of Google Analytics, which has more documentation and is considered to be more reliable in terms of measurement.