### PR TITLE
Optimize scripts in header

### DIFF
--- a/404.html
+++ b/404.html
@@ -48,17 +48,18 @@
 		</div>
 
 		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/jquery.scrolly.min.js"></script>
-			<script src="assets/js/jquery.dropotron.min.js"></script>
-			<script src="assets/js/jquery.scrollex.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
-			<script>
-				$("#header").load("assets/nav/header.html");
-				$("#footer").load("assets/nav/footer.html");
-			</script>
+		<script src="assets/js/jquery.min.js"></script>
+<!--			<script src="assets/js/jquery.scrolly.min.js"></script> -->
+<!--			<script src="assets/js/main.js"></script> -->
+		<script src="assets/js/jquery.dropotron.min.js"></script>
+		<script src="assets/js/jquery.scrollex.min.js"></script>
+		<script src="assets/js/browser.min.js"></script>
+		<script src="assets/js/breakpoints.min.js"></script>
+		<script src="assets/js/util.js"></script>
+		<script src="assets/js/typewriter.js"></script>
+		<script>
+			$("#header").load("assets/nav/header.html");
+			$("#footer").load("assets/nav/footer.html");
+		</script>
 	</body>
 </html>

--- a/404.html
+++ b/404.html
@@ -49,7 +49,7 @@
 
 		<!-- Scripts -->
 		<script src="assets/js/jquery.min.js"></script>
-<!--			<script src="assets/js/jquery.scrolly.min.js"></script> -->
+			<script src="assets/js/jquery.scrolly.min.js"></script>
 <!--			<script src="assets/js/main.js"></script> -->
 		<script src="assets/js/jquery.dropotron.min.js"></script>
 		<script src="assets/js/jquery.scrollex.min.js"></script>

--- a/assets/nav/header.html
+++ b/assets/nav/header.html
@@ -32,5 +32,5 @@
 <!-- <script src="assets/js/breakpoints.min.js"></script> -->
 <!-- <script src="assets/js/util.js"></script> -->
 <!-- <script src="assets/js/typewriter.js"></script> -->
+<!-- <script src="assets/js/jquery.scrolly.min.js"></script> -->
 <script src="assets/js/main.js"></script>
-<script src="assets/js/jquery.scrolly.min.js"></script>

--- a/assets/nav/header.html
+++ b/assets/nav/header.html
@@ -25,11 +25,12 @@
   </nav>
 </header>
 
-<script src="assets/js/jquery.min.js"></script>
-<script src="assets/js/jquery.scrolly.min.js"></script>
-<script src="assets/js/jquery.dropotron.min.js"></script>
-<script src="assets/js/jquery.scrollex.min.js"></script>
-<script src="assets/js/browser.min.js"></script>
-<script src="assets/js/breakpoints.min.js"></script>
-<script src="assets/js/util.js"></script>
+<!-- <script src="assets/js/jquery.min.js"></script> -->
+<!-- <script src="assets/js/jquery.dropotron.min.js"></script> -->
+<!-- <script src="assets/js/jquery.scrollex.min.js"></script> -->
+<!-- <script src="assets/js/browser.min.js"></script> -->
+<!-- <script src="assets/js/breakpoints.min.js"></script> -->
+<!-- <script src="assets/js/util.js"></script> -->
+<!-- <script src="assets/js/typewriter.js"></script> -->
 <script src="assets/js/main.js"></script>
+<script src="assets/js/jquery.scrolly.min.js"></script>

--- a/coming-soon.html
+++ b/coming-soon.html
@@ -48,7 +48,7 @@
 
 		<!-- Scripts -->
 		<script src="assets/js/jquery.min.js"></script>
-<!--			<script src="assets/js/jquery.scrolly.min.js"></script> -->
+			<script src="assets/js/jquery.scrolly.min.js"></script>
 <!--			<script src="assets/js/main.js"></script> -->
 		<script src="assets/js/jquery.dropotron.min.js"></script>
 		<script src="assets/js/jquery.scrollex.min.js"></script>

--- a/coming-soon.html
+++ b/coming-soon.html
@@ -47,17 +47,18 @@
 		</div>
 
 		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/jquery.scrolly.min.js"></script>
-			<script src="assets/js/jquery.dropotron.min.js"></script>
-			<script src="assets/js/jquery.scrollex.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
-			<script>
-				$("#header").load("assets/nav/header.html");
-				$("#footer").load("assets/nav/footer.html");
-			</script>
+		<script src="assets/js/jquery.min.js"></script>
+<!--			<script src="assets/js/jquery.scrolly.min.js"></script> -->
+<!--			<script src="assets/js/main.js"></script> -->
+		<script src="assets/js/jquery.dropotron.min.js"></script>
+		<script src="assets/js/jquery.scrollex.min.js"></script>
+		<script src="assets/js/browser.min.js"></script>
+		<script src="assets/js/breakpoints.min.js"></script>
+		<script src="assets/js/util.js"></script>
+		<script src="assets/js/typewriter.js"></script>
+		<script>
+			$("#header").load("assets/nav/header.html");
+			$("#footer").load("assets/nav/footer.html");
+		</script>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -173,13 +173,13 @@
 
 		<!-- Scripts -->
 			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/jquery.scrolly.min.js"></script>
+<!--			<script src="assets/js/jquery.scrolly.min.js"></script> -->
+<!--			<script src="assets/js/main.js"></script> -->
 			<script src="assets/js/jquery.dropotron.min.js"></script>
 			<script src="assets/js/jquery.scrollex.min.js"></script>
 			<script src="assets/js/browser.min.js"></script>
 			<script src="assets/js/breakpoints.min.js"></script>
 			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
 			<script src="assets/js/typewriter.js"></script>
 			<script>
 				$("#header").load("assets/nav/header.html");

--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
 
 		<!-- Scripts -->
 			<script src="assets/js/jquery.min.js"></script>
-<!--			<script src="assets/js/jquery.scrolly.min.js"></script> -->
+			<script src="assets/js/jquery.scrolly.min.js"></script>
 <!--			<script src="assets/js/main.js"></script> -->
 			<script src="assets/js/jquery.dropotron.min.js"></script>
 			<script src="assets/js/jquery.scrollex.min.js"></script>

--- a/onboarding.html
+++ b/onboarding.html
@@ -147,7 +147,7 @@
 
 		<!-- Scripts -->
 		<script src="assets/js/jquery.min.js"></script>
-<!--			<script src="assets/js/jquery.scrolly.min.js"></script> -->
+			<script src="assets/js/jquery.scrolly.min.js"></script>
 <!--			<script src="assets/js/main.js"></script> -->
 		<script src="assets/js/jquery.dropotron.min.js"></script>
 		<script src="assets/js/jquery.scrollex.min.js"></script>

--- a/onboarding.html
+++ b/onboarding.html
@@ -146,17 +146,18 @@
 		</div>
 
 		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/jquery.scrolly.min.js"></script>
-			<script src="assets/js/jquery.dropotron.min.js"></script>
-			<script src="assets/js/jquery.scrollex.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
-			<script>
-				$("#header").load("assets/nav/header.html");
-				$("#footer").load("assets/nav/footer.html");
-			</script>
+		<script src="assets/js/jquery.min.js"></script>
+<!--			<script src="assets/js/jquery.scrolly.min.js"></script> -->
+<!--			<script src="assets/js/main.js"></script> -->
+		<script src="assets/js/jquery.dropotron.min.js"></script>
+		<script src="assets/js/jquery.scrollex.min.js"></script>
+		<script src="assets/js/browser.min.js"></script>
+		<script src="assets/js/breakpoints.min.js"></script>
+		<script src="assets/js/util.js"></script>
+		<script src="assets/js/typewriter.js"></script>
+		<script>
+			$("#header").load("assets/nav/header.html");
+			$("#footer").load("assets/nav/footer.html");
+		</script>
 	</body>
 </html>

--- a/resume.html
+++ b/resume.html
@@ -240,13 +240,14 @@
 
 			<!-- Scripts -->
 			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/jquery.scrolly.min.js"></script>
+<!--			<script src="assets/js/jquery.scrolly.min.js"></script> -->
+<!--			<script src="assets/js/main.js"></script> -->
 			<script src="assets/js/jquery.dropotron.min.js"></script>
 			<script src="assets/js/jquery.scrollex.min.js"></script>
 			<script src="assets/js/browser.min.js"></script>
 			<script src="assets/js/breakpoints.min.js"></script>
 			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+			<script src="assets/js/typewriter.js"></script>
 			<script>
 				$("#header").load("assets/nav/header.html");
 				$("#footer").load("assets/nav/footer.html");

--- a/resume.html
+++ b/resume.html
@@ -240,7 +240,7 @@
 
 			<!-- Scripts -->
 			<script src="assets/js/jquery.min.js"></script>
-<!--			<script src="assets/js/jquery.scrolly.min.js"></script> -->
+			<script src="assets/js/jquery.scrolly.min.js"></script>
 <!--			<script src="assets/js/main.js"></script> -->
 			<script src="assets/js/jquery.dropotron.min.js"></script>
 			<script src="assets/js/jquery.scrollex.min.js"></script>


### PR DESCRIPTION
This PR leaves only main.js as script in header.html, commenting all others out.
In the same way, all others script load in the main pages, but main.js is commented out to avoid double load.

This PR also solves issue https://github.com/steroman/steroman.github.io/issues/49, which was probably caused by script loops.